### PR TITLE
[add] annotationでホスト名を指定できるようにした

### DIFF
--- a/agent/annotations.go
+++ b/agent/annotations.go
@@ -1,3 +1,5 @@
 package agent
 
 const AnnotationNetworkVlanID = "n0core/provisioning/virtual_machine/vlan_id"
+
+const AnnotationHostName = "n0core/provisioning/virtual_machine/hostname"


### PR DESCRIPTION
CreateVirtualMachineのannotationsでホスト名を指定できるようにした。

```
  annotations:
    n0core/provisioning/virtual_machine/hostname: "hostname"
```
agent/agent.goのBootVirtualMachineのconfigdrive.StructConfigで指定される。
もし、hostnameが指定されていない場合はnameで指定された文字列になる。
